### PR TITLE
Fix Enums in Repeated field

### DIFF
--- a/src/Generator/Message/ReadFieldStatementGenerator.php
+++ b/src/Generator/Message/ReadFieldStatementGenerator.php
@@ -88,7 +88,13 @@ class ReadFieldStatementGenerator extends BaseGenerator
             $body[] = '}';
             $body[] = null;
             $body[] = 'while ($stream->tell() < $innerLimit) {';
-            $body[] = '    ' . $variable . '->add(' . $this->generateReadScalarStatement($type->value()) . ');';
+
+            if ($type === Type::TYPE_ENUM()) {
+                $body[] = '    '.$variable.'->add('.$reference.'::valueOf('.$this->generateReadScalarStatement($type->value()).'));';
+            } else {
+                $body[] = '    '.$variable.'->add('.$this->generateReadScalarStatement($type->value()).');';
+            }
+
             $body[] = '}';
             $body[] = null;
             $body[] = $breakSttm;


### PR DESCRIPTION
The plugin generates this code for Repeated Enums: https://github.com/jaspervdm/pogoprotos-php/blob/413642db70dc66a98f99c990ceeeec4b9120706a/src/POGOProtos/Data/PlayerData.php#L780 
This leads to a TypeError, since `\Protobuf\EnumCollection->add` expects an `\Protobuf\Enum`, not an `int`.

*CC jaspervdm/pogoprotos-php#8*